### PR TITLE
Fix some build issues

### DIFF
--- a/notes_week2a.tex
+++ b/notes_week2a.tex
@@ -38,12 +38,6 @@
 \setenumerate{noitemsep, topsep=0pt, leftmargin=*}
 \setdescription{noitemsep, topsep=0pt, leftmargin=*}
 
-\newacronym{HoTT}{HoTT}{homotopy type theory}
-\newacronym{IPL}{IPL}{intuitionistic propositional logic}
-\newacronym{TT}{TT}{intuitionistic type theory}
-\newacronym{LEM}{LEM}{law of the excluded middle}
-\newacronym{ITT}{ITT}{intensional type theory}
-\newacronym{ETT}{ETT}{extensional type theory}
 \newacronym{DP}{DP}{disjunction property}
 
 


### PR DESCRIPTION
Fixes two issues
- Latex package options are supposed to be comma separated with no spaces. Some implementations accept the space, but all should accept no space.
- Acronyms were defined in macros.tex, but also in week2a. Duplicate definition yields errors at build time, so I removed them from week2a.
