### PR TITLE
notes_week3.tex: Added "x : A" to the clause of the \beta rules

### DIFF
--- a/notes_week3.tex
+++ b/notes_week3.tex
@@ -206,10 +206,10 @@ We can think of $0$ as being zero and $s$ as being the successor operation, whic
 
 The $\beta$-rules for $\Nat$ are what they `should be':
 \begin{equation*}
-\infer[\beta{\text{-}}\Nat_0]{\Gamma \vdash \rec(P,Q)(0) \equiv P : A}{\Gamma \vdash P : A & \Gamma \vdash Q : A}
+\infer[\beta{\text{-}}\Nat_0]{\Gamma \vdash \rec(P,Q)(0) \equiv P : A}{\Gamma \vdash P : A & \Gamma, x : A \vdash Q : A}
 \end{equation*}
 \begin{equation*}
-\infer[\beta{\text{-}}\Nat_s]{\Gamma \vdash \rec(P,Q)(s(M)) \equiv [\rec(P,Q)(M)/x]Q : A}{\Gamma \vdash P : A & \Gamma \vdash Q : A}
+\infer[\beta{\text{-}}\Nat_s]{\Gamma \vdash \rec(P,Q)(s(M)) \equiv [\rec(P,Q)(M)/x]Q : A}{\Gamma \vdash P : A & \Gamma, x : A \vdash Q : A}
 \end{equation*}
 
 The $\eta$-rule for the \acs{NNO} is somewhat ugly:


### PR DESCRIPTION
Added "x : A" to the clause of the \beta rules. If we don't add this, we can't replace x by rec(P, Q)(M) in the conclusion of the \beta-Nat_s rule.