### PR TITLE
Fixing mistake in second rule of type equality

### DIFF
--- a/notes_week3.tex
+++ b/notes_week3.tex
@@ -429,7 +429,7 @@ The following rules together are called \emph{functionality}
 Finally, the following rules are \emph{type equality}, which tell us that definitionally equal types classify the same things:
 \begin{equation*}
 \infer{\Gamma \vdash M : A'}{\Gamma \vdash M:A & \Gamma \vdash A \equiv A'} \hspace{50pt}
-\infer{\Gamma \vdash M \equiv M' : A}{\Gamma \vdash M \equiv M' : A & \Gamma \vdash A \equiv A'}
+\infer{\Gamma \vdash M \equiv M' : A'}{\Gamma \vdash M \equiv M' : A & \Gamma \vdash A \equiv A'}
 \end{equation*}
 
 %%% REFERENCES APPEAR HERE %%%


### PR DESCRIPTION
In the second rule of type equality A should be replaced by A' in the conclusiomn (otherwise the rule holds trivially). In the lecture this rule is written correctly on the blackboard.