### PR TITLE
Missing M:Nat assumption

### DIFF
--- a/notes_week3.tex
+++ b/notes_week3.tex
@@ -209,7 +209,7 @@ The $\beta$-rules for $\Nat$ are what they `should be':
 \infer[\beta{\text{-}}\Nat_0]{\Gamma \vdash \rec(P,Q)(0) \equiv P : A}{\Gamma \vdash P : A & \Gamma, x : A \vdash Q : A}
 \end{equation*}
 \begin{equation*}
-\infer[\beta{\text{-}}\Nat_s]{\Gamma \vdash \rec(P,Q)(s(M)) \equiv [\rec(P,Q)(M)/x]Q : A}{\Gamma \vdash P : A & \Gamma, x : A \vdash Q : A}
+\infer[\beta{\text{-}}\Nat_s]{\Gamma \vdash \rec(P,Q)(s(M)) \equiv [\rec(P,Q)(M)/x]Q : A}{\Gamma \vdash M : \Nat & \Gamma \vdash P : A & \Gamma, x : A \vdash Q : A}
 \end{equation*}
 
 The $\eta$-rule for the \acs{NNO} is somewhat ugly:


### PR DESCRIPTION
M is used as an assumption of s(M) in the lhs of the equivalence:

Current form:
Γ⊢P :A Γ⊢Q:A
——
Γ ⊢ rec(P, Q)(s(M )) ≡ [rec(P, Q)(M )/x]Q : A

Desired form
Γ ⊢ M:Nat Γ⊢P :A Γ⊢Q:A
——
Γ ⊢ rec(P, Q)(s(M )) ≡ [rec(P, Q)(M )/x]Q : A